### PR TITLE
fix grep bracket errors

### DIFF
--- a/init-db
+++ b/init-db
@@ -7,7 +7,7 @@
 #-------------------------- BEGIN: Execution --------------------------------
 
 cd ${PROJECT_ROOT}/${DOCROOT}
-SITES=$(fin drush sa --format=list | tr -d '\@:\r\'\' | sed -e 's/\..*$//' | sort | uniq)
+SITES=$(fin drush sa --format=list | grep @ | tr -d '\@:\r\'\' | sed -e 's/\..*$//' | sort | uniq)
 cd ${PROJECT_ROOT}
 
 for SITE in $SITES; do


### PR DESCRIPTION
this was causing init-db to create empty databases due to docksal warning messages